### PR TITLE
Fix small typo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -132,7 +132,7 @@
 <li><p>The <a href="#replies">Reply</a> layer is composed of “templates” that are responsible for constructing the respective response.</p></li>
 </ul>
 
-<p>In addition to being inspired by Model-View-Controller (MVC) pattern, Stealth as a few other awesome things built in for you.</p>
+<p>In addition to being inspired by Model-View-Controller (MVC) pattern, Stealth has a few other awesome things built in for you.</p>
 
 <ul>
 <li><p><strong>Plug and play services.</strong> Every service integration in Stealth is a Ruby gem. One bot can support <a href="#messaging_integrations">multiple chat services</a> (i.e. Facebook Messenger, SMS, Alexa, and more) and multiple NLP/NLU services.</p></li>


### PR DESCRIPTION
This PR fixes a small typo at `docs/index.html`.